### PR TITLE
Add JWT auth with swagger security

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,14 @@ Outbox Pattern implementation using [Quartz.NET](https://github.com/quartznet/qu
 2. Execute InitializeDatabase.sql script.
 3. Set connection string using environment variable named `ASPNETCORE_SampleProject_IntegrationTests_ConnectionString`
 - Run tests from project [src/Tests/SampleProject.IntegrationTests](src/Tests/SampleProject.IntegrationTests)
+
+## Authentication
+
+The API uses JWT bearer authentication. Obtain a token by sending the credentials defined under the `Auth` section of `appsettings.json` to `POST /api/auth/token`.
+Include the returned token in the `Authorization` header when calling other endpoints:
+
+```
+Authorization: Bearer {token}
+```
+
+The OpenAPI specification is served at `/swagger/v1/swagger.json`. You can upload this file to [Scalar Swagger Editor](https://docs.scalar.com/swagger-editor) for interactive documentation.

--- a/src/SampleProject.API/Authentication/AuthController.cs
+++ b/src/SampleProject.API/Authentication/AuthController.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+using SampleProject.API.Configuration;
+
+namespace SampleProject.API.Authentication
+{
+    [Route("api/auth")]
+    [ApiController]
+    public class AuthController : Controller
+    {
+        private readonly AuthSettings _settings;
+
+        public AuthController(AuthSettings settings)
+        {
+            _settings = settings;
+        }
+
+        [AllowAnonymous]
+        [HttpPost("token")]
+        public IActionResult GetToken([FromBody] AuthRequest request)
+        {
+            if (request.Username == _settings.Username && request.Password == _settings.Password)
+            {
+                var claims = new[] { new Claim(ClaimTypes.Name, request.Username) };
+                var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_settings.SecretKey));
+                var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+                var token = new JwtSecurityToken(
+                    issuer: _settings.Issuer,
+                    audience: _settings.Audience,
+                    claims: claims,
+                    expires: DateTime.Now.AddHours(1),
+                    signingCredentials: creds);
+
+                return Ok(new { token = new JwtSecurityTokenHandler().WriteToken(token) });
+            }
+
+            return Unauthorized();
+        }
+    }
+}

--- a/src/SampleProject.API/Authentication/AuthRequest.cs
+++ b/src/SampleProject.API/Authentication/AuthRequest.cs
@@ -1,0 +1,8 @@
+namespace SampleProject.API.Authentication
+{
+    public class AuthRequest
+    {
+        public string Username { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/src/SampleProject.API/Configuration/AuthSettings.cs
+++ b/src/SampleProject.API/Configuration/AuthSettings.cs
@@ -1,0 +1,11 @@
+namespace SampleProject.API.Configuration
+{
+    public class AuthSettings
+    {
+        public string Issuer { get; set; }
+        public string Audience { get; set; }
+        public string SecretKey { get; set; }
+        public string Username { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/src/SampleProject.API/Configuration/SwaggerExtensions.cs
+++ b/src/SampleProject.API/Configuration/SwaggerExtensions.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 
 namespace SampleProject.API.Configuration
 {
@@ -12,7 +13,7 @@ namespace SampleProject.API.Configuration
         {
             services.AddSwaggerGen(options =>
             {
-                options.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo
+                options.SwaggerDoc("v1", new OpenApiInfo
                 {
                     Title = "Sample CQRS API",
                     Version = "v1",
@@ -23,6 +24,21 @@ namespace SampleProject.API.Configuration
                 var commentsFileName = Assembly.GetExecutingAssembly().GetName().Name + ".XML";
                 var commentsFile = Path.Combine(baseDirectory, commentsFileName);
                 options.IncludeXmlComments(commentsFile);
+
+                var securityScheme = new OpenApiSecurityScheme
+                {
+                    Name = "Authorization",
+                    Type = SecuritySchemeType.Http,
+                    Scheme = "bearer",
+                    BearerFormat = "JWT",
+                    In = ParameterLocation.Header,
+                    Description = "JWT Authorization header using the Bearer scheme",
+                };
+                options.AddSecurityDefinition("Bearer", securityScheme);
+                options.AddSecurityRequirement(new OpenApiSecurityRequirement
+                {
+                    { securityScheme, new string[] { } }
+                });
             });
 
             return services;

--- a/src/SampleProject.API/Customers/CustomersController.cs
+++ b/src/SampleProject.API/Customers/CustomersController.cs
@@ -1,15 +1,17 @@
 ﻿using System.Net;
 using System.Threading.Tasks;
 using Cortex.Mediator;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SampleProject.Application.Customers;
 using SampleProject.Application.Customers.RegisterCustomer;
 
 namespace SampleProject.API.Customers
 {
-    [Route("api/customers")]
-    [ApiController]
-    public class CustomersController : Controller
+[Route("api/customers")]
+[ApiController]
+[Authorize]
+public class CustomersController : Controller
     {
         private readonly IMediator _mediator;
 

--- a/src/SampleProject.API/Orders/CustomerOrdersController.cs
+++ b/src/SampleProject.API/Orders/CustomerOrdersController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using Cortex.Mediator;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SampleProject.Application.Orders.ChangeCustomerOrder;
 using SampleProject.Application.Orders.GetCustomerOrderDetails;
@@ -12,9 +13,10 @@ using SampleProject.Application.Orders.RemoveCustomerOrder;
 
 namespace SampleProject.API.Orders
 {
-    [Route("api/customers")]
-    [ApiController]
-    public class CustomerOrdersController : Controller
+[Route("api/customers")]
+[ApiController]
+[Authorize]
+public class CustomerOrdersController : Controller
     {
         private readonly IMediator _mediator;
 

--- a/src/SampleProject.API/SampleProject.API.csproj
+++ b/src/SampleProject.API/SampleProject.API.csproj
@@ -23,20 +23,21 @@
     <None Remove="SampleProject.Domain\**" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Autofac.Extras.CommonServiceLocator" Version="5.0.0" />
-    <PackageReference Include="Dapper" Version="2.0.30" />
-    <PackageReference Include="FluentValidation" Version="8.6.1" />
-    <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="3.1.0" />
-    <PackageReference Include="Cortex.Mediator" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.0" />
-    <PackageReference Include="Quartz" Version="3.0.7" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
-  </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="5.0.1" />
+      <PackageReference Include="Autofac.Extras.CommonServiceLocator" Version="5.0.0" />
+      <PackageReference Include="Dapper" Version="2.0.30" />
+      <PackageReference Include="FluentValidation" Version="8.6.1" />
+      <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="3.1.0" />
+      <PackageReference Include="Cortex.Mediator" Version="1.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.0" />
+      <PackageReference Include="Quartz" Version="3.0.7" />
+      <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
+      <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+      <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
+      <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
+      <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.17" />
+    </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\SampleProject.Application\SampleProject.Application.csproj" />

--- a/src/SampleProject.API/appsettings.Development.json
+++ b/src/SampleProject.API/appsettings.Development.json
@@ -5,5 +5,12 @@
             "System": "Information",
             "Microsoft": "None"
         }
+    },
+    "Auth": {
+        "Issuer": "SampleIssuer",
+        "Audience": "SampleAudience",
+        "SecretKey": "VerySecretKey12345",
+        "Username": "test",
+        "Password": "test"
     }
 }

--- a/src/SampleProject.API/appsettings.Production.json
+++ b/src/SampleProject.API/appsettings.Production.json
@@ -5,5 +5,12 @@
       "System": "Information",
       "Microsoft": "Information"
     }
+  },
+  "Auth": {
+    "Issuer": "SampleIssuer",
+    "Audience": "SampleAudience",
+    "SecretKey": "VerySecretKey12345",
+    "Username": "test",
+    "Password": "test"
   }
 }

--- a/src/SampleProject.API/appsettings.json
+++ b/src/SampleProject.API/appsettings.json
@@ -12,5 +12,12 @@
     },
     "EmailsSettings": {
         "FromAddressEmail": "from@mail.com"
+    },
+    "Auth": {
+        "Issuer": "SampleIssuer",
+        "Audience": "SampleAudience",
+        "SecretKey": "VerySecretKey12345",
+        "Username": "test",
+        "Password": "test"
     }
 }


### PR DESCRIPTION
## Summary
- secure API endpoints with JWT bearer authentication
- add auth controller and config
- protect controllers with `[Authorize]`
- add swagger security scheme and mention Scalar Swagger Editor in docs

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687088719b108330a2dac8681da11fe8